### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Radius Raid#
+# Radius Raid #
 
 Radius Raid is a space themed shoot 'em up where you must blast away unrelenting enemies before they destroy you. The game features 13 enemy types, 5 powerups, parallax backgrounds, retro sound effects, and locally stored stats.
 
@@ -6,19 +6,19 @@ This is an an entry for [js13kGames](http://js13kgames.com) 2013. The theme this
 
 **Final Size:** 13,278 bytes
 
-#Controls#
+# Controls #
 **Move:** WASD/Arrows  
 **Aim/Fire:** Mouse  
 **Autofire:** F  
 **Pause:** P  
 **Mute:** M
 
-#Notes#
+# Notes #
 I hate having to say this, but from my testing, if you are not running the game in Chrome... you're gonna have a bad time. It works in other browsers, but the frame rate is just not high enough. I didn't want to sacrifice any visuals for this one. Early on, I decided I would rather have it look and play better in one browser than look ok and play ok in many browsers. It is just the state of the games in browsers at the moment and I am ok with that.
 
 I so badly wanted to use [@rezoner](https://twitter.com/rezoner)'s JavaScript chiptune composer, [CHIRP](http://chirp.rezoner.net/), but I just couldn't fit it in the limit. It really bummed me out. I composed a few ideas and really loved the feel of the music with the game. So upsetting. You should definitely check out the tool, it is amazing and will be incredibly useful for game music in the future!
 
-#Credits#
+# Credits #
 **Created By:** [@jackrugile](https://twitter.com/jackrugile)  
 **Inspiration and Support:** [@rezoner](https://twitter.com/rezoner), [@loktar00](https://twitter.com/loktar00), [@end3r](https://twitter.com/end3r), [@austinhallock](https://twitter.com/austinhallock), [@chandlerprall](https://twitter.com/chandlerprall)  
 **Audio Processing:** [JSFXR](https://github.com/mneubrand/jsfxr) by [@markusneubrand](https://twitter.com/markusneubrand)  
@@ -26,7 +26,7 @@ I so badly wanted to use [@rezoner](https://twitter.com/rezoner)'s JavaScript ch
 **HTML5 Canvas Reference:** [HTML5 Canvas Cheat Sheet](https://simon.html5.org/dump/html5-canvas-cheat-sheet.html)  
 **Game Math Reference:** Billy Lamberta - [Foundation HTML5 Animation with JavaScript](http://lamberta.github.io/html5-animation/)
 
-#Screenshots#
+# Screenshots #
 ![Radius Raid Menu](http://jackrugile.com/radius-raid/images/menu-screenshot.png "Radius Raid Menu")
 
 ![Radius Raid Gameplay](http://jackrugile.com/radius-raid/images/gameplay-screenshot.png "Radius Raid Gameplay")


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
